### PR TITLE
chore: skip wifi configuration if ssid is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ PlatformIO will handle the full build process, including dependencies, compilati
 - [micro-ROS for PlatformIO](#micro-ros-for-platformio)
   - [Supported boards](#supported-boards)
   - [Requirements](#requirements)
+    - [Platform specific requirements](#platform-specific-requirements)
+      - [MacOS](#macos)
   - [How to add to your project](#how-to-add-to-your-project)
   - [Library configuration](#library-configuration)
     - [ROS 2 distribution](#ros-2-distribution)
@@ -121,6 +123,7 @@ The transport can be configured with the `board_microros_transport = <transport>
 
     set_microros_wifi_transports(ssid, psk, agent_ip, agent_port);
     ```
+    Note: passing an empty string to `ssid` will make the library use an already configured WiFi connection.
 
   - `native_ethernet`
 

--- a/platform_code/arduino/wifi/micro_ros_transport.h
+++ b/platform_code/arduino/wifi/micro_ros_transport.h
@@ -7,7 +7,11 @@ struct micro_ros_agent_locator {
 };
 
 static inline void set_microros_wifi_transports(char * ssid, char * pass, IPAddress agent_ip, uint16_t agent_port){
-	WiFi.begin(ssid, pass);
+	
+    // if ssid is empty, skip wifi configuration and reuse the current connection
+    if (strlen(ssid) != 0) {
+        WiFi.begin(ssid, pass);
+    }
 
     while (WiFi.status() != WL_CONNECTED) {
       delay(500);

--- a/platform_code/arduino/wifi_nina/micro_ros_transport.h
+++ b/platform_code/arduino/wifi_nina/micro_ros_transport.h
@@ -8,10 +8,14 @@ struct micro_ros_agent_locator {
 };
 
 static inline void set_microros_wifi_transports(char * ssid, char * pass, IPAddress agent_ip, uint16_t agent_port){
+
+    // if ssid is empty, skip wifi configuration and reuse the current connection
+    if (strlen(ssid) != 0) {
     while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
       delay(500);
     }
-
+}
+    
     static struct micro_ros_agent_locator locator;
     locator.address = agent_ip;
     locator.port = agent_port;


### PR DESCRIPTION
Skips wifi setup if wifi already configured somewhere else. Use empty `ssid` to skip wifi setup.